### PR TITLE
Add Soul Spec: Declarative Persona Specification for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1367,6 +1367,12 @@ This discipline is foundational for unlocking the full potential of LLMs in prod
 <ul>
 <li><i><b>Personalized LLM Response Generation with Parameterized User Memory Injection</b></i>, Anonymous et al., <a href="https://arxiv.org/abs/2404.03565" target="_blank"><img src="https://img.shields.io/badge/arXiv-2024.04-red" alt="arXiv Badge"></a>
     </li>
+<li><i><b>Soul-Driven Interaction Design: A Position Paper on Declarative Persona Specifications for AI Agents</b></i>, Lee, <a href="https://doi.org/10.5281/zenodo.18678616" target="_blank"><img src="https://img.shields.io/badge/Zenodo-2026.02-blue" alt="Zenodo Badge"></a>
+    </li>
+<li><i><b>Soul Spec — Open Specification for AI Agent Persona Packages</b></i>, ClawSouls, <a href="https://clawsouls.ai/spec" target="_blank"><img src="https://img.shields.io/badge/Spec-v0.4-blue" alt="Spec Badge"></a>
+    <a href="https://github.com/clawsouls/soul-spec-mcp" target="_blank">
+        <img src="https://img.shields.io/github/stars/clawsouls/soul-spec-mcp.svg?style=social" alt="GitHub stars">
+    </a></li>
 </ul>
 
 <b>Safety and Alignment with Memory</b>


### PR DESCRIPTION
## Summary

Adds two entries to the **Personalization and Memory** section:

1. **Soul-Driven Interaction Design** — A position paper on declarative persona specifications for AI agents (Zenodo DOI: 10.5281/zenodo.18678616). Proposes structured, file-based persona packages (SOUL.md, IDENTITY.md, AGENTS.md) as a context engineering layer for behavioral consistency.

2. **Soul Spec** — An open specification (v0.4) for AI agent persona packages, with an MCP server for integration with Claude, ChatGPT, Cursor, and other frameworks. 80+ community-contributed personas available.

## Relevance to Context Engineering

Soul Spec addresses the **persona and behavioral context** gap identified in the survey — how to systematically structure the identity, tone, communication style, and workflow preferences that shape agent behavior. This complements existing work on memory systems and RAG by formalizing the *who* (persona) alongside the *what* (knowledge) in context engineering.

The MSR 2026 paper (arXiv:2510.21413) on AGENTS.md adoption found "no established content structure yet" for AI context files — Soul Spec provides exactly that standardized structure.

## Links
- Spec: https://clawsouls.ai/spec
- Paper: https://doi.org/10.5281/zenodo.18678616
- MCP Server: https://github.com/clawsouls/soul-spec-mcp
- npm: https://www.npmjs.com/package/soul-spec-mcp