### PR TITLE
Add nv:context – context engineering skill for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1964,6 +1964,7 @@ Coding agents are one of the clearest production settings in which context engin
 <li><i><b>Claude Code Subagents</b></i>, Anthropic, <a href="https://docs.anthropic.com/en/docs/claude-code/sub-agents" target="_blank"><img src="https://img.shields.io/badge/Anthropic-2026-blue" alt="Anthropic Badge"></a></li>
 <li><i><b>Letta Memory Blocks</b></i>, Letta, <a href="https://docs.letta.com/guides/core-concepts/memory/memory-blocks" target="_blank"><img src="https://img.shields.io/badge/Letta-2026-blue" alt="Letta Badge"></a></li>
 <li><i><b>LangChain Deep Agents</b></i>, LangChain, <a href="https://docs.langchain.com/oss/python/deepagents/overview" target="_blank"><img src="https://img.shields.io/badge/LangChain-2026-blue" alt="LangChain Badge"></a></li>
+<li><i><b>nv:context</b></i>, NichevLabs, <a href="https://skills.nichevlabs.com" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-green" alt="Tool Badge"></a></li>
 </ul>
 
 #### Platform Stacks and Hosted Agent Runtimes


### PR DESCRIPTION
## Summary

**nv:context** is a Claude Code skill that operationalizes context engineering for AI coding agents. It bridges the gap between static CLAUDE.md configuration and dynamic, context-aware setup that actually scales.

## What It Does

- **Auto-detects** tools in your codebase (language, build system, test framework, dev servers, APIs)
- **Scans for landmines** with parallel subagents: patterns that break agent reasoning, non-obvious constraints, context pitfalls
- **Scores 6 layers** of the Hierarchy of Leverage: repository structure, tool integration, memory artifacts, hook strategy, session management, and persona/tone
- **Generates only what you need**: CLAUDE.md, AGENTS.md, hooks, or session configs — no bloat

## The Research

Built on 200+ research sources:
- The METR study on context engineering for autonomous agents
- Manus's KV-cache optimization and attention manipulation techniques  
- JetBrains NeurIPS 2025 paper on IDE integration for agent productivity
- Analysis of 2,500+ production AGENTS.md files from open-source agent codebases

## Production Validation

Tested on 3 real codebases:
- **selectools** (4,612 tests): CLAUDE.md reduced from 440 → 67 lines (-85%), leverage 49/60 → 58/60
- **nichevlabs** (multi-product SaaS): SESSION.md from 805 → 59 lines (-93%), saving 15.8K tokens/session
- **sheriff** (Python + TypeScript): 36/60 → 42/60 leverage, iterative polish on strong baseline

## How It Fits Here

This repo's focus is context engineering **as agent engineering**—moving beyond tactical prompting to strategic system design. nv:context automates the interview-and-audit loop that should precede every agent deployment. It's a tool proving the methodologies documented in Awesome Context Engineering actually work at scale.

## Install

```bash
npx skills add johnnichev/nv-context -g -y
```

Then run `/nv-context` in any Claude Code session.

📚 Docs: https://skills.nichevlabs.com
🔗 GitHub: https://github.com/johnnichev/nv-context