### PR TITLE
Add skill-optimizer to Benchmarking Context Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1840,6 +1840,10 @@ The frontier of tool use has shifted from static function schemas to **hosted to
     <a href="https://github.com/Liu-Hy/GenoTEX" target="_blank">
   		<img src="https://img.shields.io/github/stars/Liu-Hy/GenoTEX.svg?style=social" alt="GitHub stars">
     </a></li>
+<li><i><b>skill-optimizer</b></i> — CLI that benchmarks SDK, CLI, and MCP guidance docs (SKILL.md) against multiple LLMs and iteratively rewrites them until every configured model meets a score floor.
+    <a href="https://github.com/fastxyz/skill-optimizer" target="_blank">
+  		<img src="https://img.shields.io/github/stars/fastxyz/skill-optimizer.svg?style=social" alt="GitHub stars">
+    </a></li>
 </ul>
 
 ### Agent Observability and Telemetry


### PR DESCRIPTION
skill-optimizer is a CLI tool that benchmarks your SDK, CLI, or MCP guidance docs (SKILL.md) against multiple LLMs, measuring whether models call the right tools with the right arguments. It then runs an iterative optimizer that rewrites your SKILL.md until every configured model meets a score floor — making context quality measurable and improvable in CI.

Fits under "Benchmarking Context Engineering" alongside existing tool entries that measure how well LLMs handle context and guidance docs.

Repo: https://github.com/fastxyz/skill-optimizer