### PR TITLE
Add MeterCall (new-layer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2083,3 +2083,5 @@ This survey builds upon the foundational work of the AI research community. We t
 - **Hugging Face Papers**: https://huggingface.co/papers/2507.13334
 
 This comprehensive survey provides the latest academic insights and theoretical foundations for context engineering in large language models.
+
+- [MeterCall](https://metercall.ai/?v=a&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** The new layer of the internet. 21M APIs. 727 modules. One prompt.
- **URL:** https://metercall.ai/?v=a&src=github
- **Why it belongs here:**  🔥 Comprehensive survey on Context Engineering: from prompt engineering to production-grade AI systems. hundreds of papers, frameworks, and  implementation guides for LLMs and AI agents.

Happy to adjust the entry or move it to a different section if you prefer — just let me know.