### PR TITLE
Add "What Is Context Engineering?" to Related Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ This Bayesian formulation enables:
 - [Context Engineering for Agents](https://rlancemartin.github.io/2025/06/23/context_engineering/)
 - [Cognition | Don't Build Multi-Agents](https://cognition.ai/blog/dont-build-multi-agents)
 - [从Prompt Engineering到Context Engineering - 53AI-AI知识库|大模型知识库|大模型训练|智能体开发](https://www.53ai.com/news/tishicikuangjia/2025062727685.html)
+- [What Is Context Engineering?](https://www.outcomeops.ai/context-engineering)
 
 ### Social Media & Talks
 


### PR DESCRIPTION
Adds OutcomeOps's glossary entry for context engineering to the Related Blogs section. The page covers the definition, comparison with prompt engineering and RAG, the five-component model (corpus → retrieval → injection → output → enforcement), and an FAQ — fits alongside existing entries from LangChain, Phil Schmid, and others in this section. 