### PR TITLE
Add APort to agent runtime policy references

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,6 +969,7 @@ In 2026, many of the most important advances in context engineering no longer li
 <li><i><b>Google Agent Development Kit (ADK)</b></i>, Google, <a href="https://google.github.io/adk-docs/" target="_blank"><img src="https://img.shields.io/badge/Google-2026-blue" alt="Google Badge"></a></li>
 <li><i><b>LangChain Deep Agents Overview</b></i>, LangChain, <a href="https://docs.langchain.com/oss/python/deepagents/overview" target="_blank"><img src="https://img.shields.io/badge/LangChain-2026-blue" alt="LangChain Badge"></a></li>
 <li><i><b>Microsoft Agent Framework Overview</b></i>, Microsoft, <a href="https://learn.microsoft.com/en-us/agent-framework/user-guide/overview" target="_blank"><img src="https://img.shields.io/badge/Microsoft-2026-blue" alt="Microsoft Badge"></a></li>
+<li><i><b>APort</b></i> — Agent identity verification and policy enforcement for tool calls; provides <a href="https://github.com/aporthq/aport-integrations" target="_blank">guardrail integration examples</a> for LangChain, CrewAI, and other agent runtimes. <a href="https://aport.io" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-blue" alt="Tool Badge"></a></li>
 <li><i><b>Bring Your AI</b></i> — Local-first Claude Code to Codex harness mover for rules, skills, MCP config, and validation notes. <a href="https://bringyour.ai/claude-code-to-codex" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-blue" alt="Tool Badge"></a></li>
 </ul>
 


### PR DESCRIPTION
## Summary
- Add APort to the Agent Harnesses and Runtime Systems references.
- Position it as an agent identity and policy enforcement layer for tool calls, with links to guardrail integration examples.

## Verification
- `git diff --check`
- Checked `https://aport.io` and `https://github.com/aporthq/aport-integrations` return HTTP 200.

Related bounty: https://github.com/aporthq/aport-integrations/issues/19