### PR TITLE
Add contextweaver to Context Optimization Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,10 @@ In the agent era, context engineering increasingly means **runtime context manag
     <a href="https://github.com/juyterman1000/entroly" target="_blank">
   		<img src="https://img.shields.io/github/stars/juyterman1000/entroly.svg?style=social" alt="GitHub stars">
     </a></li>
+<li><i><b>contextweaver: Phase-Specific Budgeted Context Compilation and Bounded-DAG Tool Routing</b></i> — Python library for tool-using agents. Per-phase token budgets (route / call / interpret / answer), context firewall that keeps large tool outputs out of the prompt, deterministic-by-default pipeline. Framework-agnostic — adapters for MCP, A2A, LangChain, LlamaIndex, OpenAI Agents SDK, Google ADK, Pipecat. Apache-2.0, 600+ tests, minimal core deps. <a href="https://github.com/dgenio/contextweaver" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-green" alt="Tool Badge"></a>
+    <a href="https://github.com/dgenio/contextweaver" target="_blank">
+  		<img src="https://img.shields.io/github/stars/dgenio/contextweaver.svg?style=social" alt="GitHub stars">
+    </a></li>
 </ul>
 
 <b>Production Design Questions</b>


### PR DESCRIPTION
Adds [contextweaver](https://github.com/dgenio/contextweaver) to the **Context Optimization Engines** subsection under Components → Context Management in Production, alongside Entroly.

It's a Python library that addresses the runtime context management pattern described in the section's intro — compaction, artifact-backed state, and scoped context loading — with two cooperating engines:

- **Context Engine**: 8-stage pipeline that compiles phase-specific (route / call / interpret / answer), budget-aware prompts. A context firewall stores large tool outputs out-of-band and injects compact summaries so they don't consume the token budget.
- **Routing Engine**: bounded-DAG + beam-search navigation over large tool catalogs so the LLM sees a focused shortlist (ChoiceCards) instead of every full tool schema.

Apache-2.0, Python 3.10+, on PyPI, 600+ tests, minimal core dependencies. Framework-agnostic — first-party adapters for MCP, A2A, LangChain / LangGraph, LlamaIndex, OpenAI Agents SDK, Google ADK, and Pipecat.

Format follows the existing Entroly entry in the same subsection. Happy to adjust wording or badge style if you'd prefer something different. Thanks for maintaining this list!