### PR TITLE
## Add human-context to Coding Agents and Project Memory  **Tool:** [human-context](https://github.com/zzgiabaozzbui/human-context)  **What it does:** A zero-dependency, single HTML file that lets you open any project folder and instantly navigate all its `.md` files as a structured knowledge base — with syntax highlighting, TOC, dark mode, token counting, and cross-file navigation. No server, no npm install, no build step.  **Why it fits here:** human-context is specifically built for context engineering with AI coding agents. You drop it into a project alongside `CLAUDE.md` / `memory.md` / `docs/` and it makes the entire knowledge layer instantly readable — directly addressing the "project memory and instruction artifacts" problem described in this section.  **Section:** Applications and Systems → Production Systems → Coding Agents and Project MemoryAdd 'human-context' tool to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1981,6 +1981,7 @@ Coding agents are one of the clearest production settings in which context engin
 <li><i><b>Letta Memory Blocks</b></i>, Letta, <a href="https://docs.letta.com/guides/core-concepts/memory/memory-blocks" target="_blank"><img src="https://img.shields.io/badge/Letta-2026-blue" alt="Letta Badge"></a></li>
 <li><i><b>LangChain Deep Agents</b></i>, LangChain, <a href="https://docs.langchain.com/oss/python/deepagents/overview" target="_blank"><img src="https://img.shields.io/badge/LangChain-2026-blue" alt="LangChain Badge"></a></li>
 <li><i><b>nv:context</b></i>, NichevLabs, <a href="https://skills.nichevlabs.com" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-green" alt="Tool Badge"></a></li>
+<li><i><b>human-context</b></i>, zzgiabaozzbui, <a href="https://github.com/zzgiabaozzbui/human-context" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-green" alt="Tool Badge"></a> — Zero-dependency HTML viewer for navigating project markdown as AI-readable context</li>
 </ul>
 
 #### Platform Stacks and Hosted Agent Runtimes


### PR DESCRIPTION
Added a new entry for 'human-context' tool with a description.