### PR TITLE
Add Pluribus to coding agent context resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1983,10 +1983,7 @@ Coding agents are one of the clearest production settings in which context engin
 <li><i><b>Letta Memory Blocks</b></i>, Letta, <a href="https://docs.letta.com/guides/core-concepts/memory/memory-blocks" target="_blank"><img src="https://img.shields.io/badge/Letta-2026-blue" alt="Letta Badge"></a></li>
 <li><i><b>LangChain Deep Agents</b></i>, LangChain, <a href="https://docs.langchain.com/oss/python/deepagents/overview" target="_blank"><img src="https://img.shields.io/badge/LangChain-2026-blue" alt="LangChain Badge"></a></li>
 <li><i><b>nv:context</b></i>, NichevLabs, <a href="https://skills.nichevlabs.com" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-green" alt="Tool Badge"></a></li>
-<li><i><b>Pluribus</b></i>, Caio Ribeiro, <a href="https://github.com/caioribeiroclw-pixel/pluribus" target="_blank"><img src="https://img.shields.io/badge/GitHub-2026-white" alt="GitHub Badge"></a> — privacy-safe context receipts for AI coding agents, covering cross-tool project context, memory, tools, skills, compaction, and instruction-loading boundaries.
-    <a href="https://github.com/caioribeiroclw-pixel/pluribus" target="_blank">
-		<img src="https://img.shields.io/github/stars/caioribeiroclw-pixel/pluribus.svg?style=social" alt="GitHub stars">
-    </a></li>
+<li><i><b>Pluribus</b></i>, Caio Ribeiro, <a href="https://github.com/caioribeiroclw-pixel/pluribus" target="_blank"><img src="https://img.shields.io/badge/GitHub-2026-white" alt="GitHub Badge"></a> — syncs one reviewed project-context source into native AI coding-tool files, with privacy-safe evidence that distinguishes generated files from runtime-loaded context.</li>
 </ul>
 
 #### Platform Stacks and Hosted Agent Runtimes

--- a/README.md
+++ b/README.md
@@ -1983,6 +1983,10 @@ Coding agents are one of the clearest production settings in which context engin
 <li><i><b>Letta Memory Blocks</b></i>, Letta, <a href="https://docs.letta.com/guides/core-concepts/memory/memory-blocks" target="_blank"><img src="https://img.shields.io/badge/Letta-2026-blue" alt="Letta Badge"></a></li>
 <li><i><b>LangChain Deep Agents</b></i>, LangChain, <a href="https://docs.langchain.com/oss/python/deepagents/overview" target="_blank"><img src="https://img.shields.io/badge/LangChain-2026-blue" alt="LangChain Badge"></a></li>
 <li><i><b>nv:context</b></i>, NichevLabs, <a href="https://skills.nichevlabs.com" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-green" alt="Tool Badge"></a></li>
+<li><i><b>Pluribus</b></i>, Caio Ribeiro, <a href="https://github.com/caioribeiroclw-pixel/pluribus" target="_blank"><img src="https://img.shields.io/badge/GitHub-2026-white" alt="GitHub Badge"></a> — privacy-safe context receipts for AI coding agents, covering cross-tool project context, memory, tools, skills, compaction, and instruction-loading boundaries.
+    <a href="https://github.com/caioribeiroclw-pixel/pluribus" target="_blank">
+		<img src="https://img.shields.io/github/stars/caioribeiroclw-pixel/pluribus.svg?style=social" alt="GitHub stars">
+    </a></li>
 </ul>
 
 #### Platform Stacks and Hosted Agent Runtimes


### PR DESCRIPTION
Adds one minimal Pluribus entry under **Coding Agents and Project Memory**.

Why this section fits:
- Pluribus syncs one reviewed project-context source into native AI coding-tool files.
- It emits privacy-safe evidence while keeping generated files distinct from runtime-loaded context.
- It is not a memory backend, retrieval system, or agent framework.

I consolidated the overlapping #68 and #82 submissions into this PR to leave maintainers one small review surface.

Validation: `git diff --check` passes.