### PR TITLE
Add Pluribus to coding agent project memory resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1983,6 +1983,7 @@ Coding agents are one of the clearest production settings in which context engin
 <li><i><b>Letta Memory Blocks</b></i>, Letta, <a href="https://docs.letta.com/guides/core-concepts/memory/memory-blocks" target="_blank"><img src="https://img.shields.io/badge/Letta-2026-blue" alt="Letta Badge"></a></li>
 <li><i><b>LangChain Deep Agents</b></i>, LangChain, <a href="https://docs.langchain.com/oss/python/deepagents/overview" target="_blank"><img src="https://img.shields.io/badge/LangChain-2026-blue" alt="LangChain Badge"></a></li>
 <li><i><b>nv:context</b></i>, NichevLabs, <a href="https://skills.nichevlabs.com" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-green" alt="Tool Badge"></a></li>
+<li><i><b>Pluribus</b></i>, Caio Ribeiro, <a href="https://github.com/caioribeiroclw-pixel/pluribus" target="_blank"><img src="https://img.shields.io/badge/GitHub-2026-white" alt="GitHub Badge"></a> — syncs versioned project context and instruction artifacts across AI coding tools such as Claude Code, Cursor, GitHub Copilot, and OpenClaw.</li>
 </ul>
 
 #### Platform Stacks and Hosted Agent Runtimes


### PR DESCRIPTION
Adds Pluribus to the "Coding Agents and Project Memory" section.

Why it fits this section:
- Pluribus is focused on versioned project context / instruction artifacts for AI coding tools.
- It syncs context across Claude Code, Cursor, GitHub Copilot, OpenClaw, and adjacent workflows.
- It is not a memory backend or agent framework; the entry is placed with project-memory / coding-agent context resources.

Kept the entry to one line and followed the existing GitHub badge style.
