### PR TITLE
Add Pluribus to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1970,6 +1970,10 @@ Long-running agent systems need more than offline benchmark scores. They require
     <a href="https://github.com/autohandai/code-cli" target="_blank">
   		<img src="https://img.shields.io/github/stars/autohandai/code-cli.svg?style=social" alt="GitHub stars">
     </a></li>
+<li><i><b>Pluribus: Portable Project Context and Receipts for AI Coding Tools</b></i>, Caio Ribeiro, <a href="https://github.com/caioribeiroclw-pixel/pluribus" target="_blank"><img src="https://img.shields.io/badge/Tool-2026-green" alt="Tool Badge"></a> — syncs versioned project context across Claude Code, Cursor, Copilot, OpenClaw, and adjacent tools, with receipt-oriented demos for context budgets, boundaries, and loaded instructions.
+    <a href="https://github.com/caioribeiroclw-pixel/pluribus" target="_blank">
+        <img src="https://img.shields.io/github/stars/caioribeiroclw-pixel/pluribus.svg?style=social" alt="GitHub stars">
+    </a></li>
 </ul>
 
 #### Coding Agents and Project Memory


### PR DESCRIPTION
Adds Pluribus under Developer Tools with Context Engineering. It is a small open-source tool for syncing versioned project context across AI coding tools (Claude Code, Cursor, Copilot, OpenClaw) and for experimenting with receipt-style context budget / boundary demos.\n\nI placed it in the developer tools section rather than memory/compression because the project is about portable project context and auditable loaded-instruction/boundary receipts, not a long-term memory layer.